### PR TITLE
[ADD] @Builder 어노테이션 사용 방법 변경

### DIFF
--- a/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
+++ b/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
@@ -19,7 +19,7 @@ import shop.cazait.domain.cafe.entity.Cafe;
 import shop.cazait.global.common.entity.BaseEntity;
 
 @Entity
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CafeCongestion extends BaseEntity {
 
@@ -41,4 +41,5 @@ public class CafeCongestion extends BaseEntity {
         this.cafe = cafe;
         this.status = status;
     }
+
 }

--- a/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
+++ b/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
@@ -36,8 +36,7 @@ public class CafeCongestion extends BaseEntity {
     private CongestionStatus status;
 
     @Builder
-    public CafeCongestion(Long id, Cafe cafe, CongestionStatus status) {
-        this.id = id;
+    public CafeCongestion(Cafe cafe, CongestionStatus status) {
         this.cafe = cafe;
         this.status = status;
     }

--- a/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
+++ b/src/main/java/shop/cazait/domain/cafecongestion/entity/CafeCongestion.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,9 +19,7 @@ import shop.cazait.domain.cafe.entity.Cafe;
 import shop.cazait.global.common.entity.BaseEntity;
 
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class CafeCongestion extends BaseEntity {
 
@@ -36,4 +35,10 @@ public class CafeCongestion extends BaseEntity {
     @Column(nullable = false)
     private CongestionStatus status;
 
+    @Builder
+    public CafeCongestion(Long id, Cafe cafe, CongestionStatus status) {
+        this.id = id;
+        this.cafe = cafe;
+        this.status = status;
+    }
 }

--- a/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
+++ b/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
+++ b/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,9 +17,7 @@ import shop.cazait.domain.cafe.entity.Cafe;
 import shop.cazait.domain.user.entity.User;
 
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CafeFavorites {
 
@@ -36,4 +35,10 @@ public class CafeFavorites {
     @Column(nullable = false)
     private Cafe cafe;
 
+    @Builder
+    public CafeFavorites(Long id, User user, Cafe cafe) {
+        this.id = id;
+        this.user = user;
+        this.cafe = cafe;
+    }
 }

--- a/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
+++ b/src/main/java/shop/cazait/domain/cafefavorites/entity/CafeFavorites.java
@@ -35,8 +35,7 @@ public class CafeFavorites {
     private Cafe cafe;
 
     @Builder
-    public CafeFavorites(Long id, User user, Cafe cafe) {
-        this.id = id;
+    public CafeFavorites(User user, Cafe cafe) {
         this.user = user;
         this.cafe = cafe;
     }

--- a/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
+++ b/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
+++ b/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,9 +16,7 @@ import lombok.NoArgsConstructor;
 import shop.cazait.domain.cafe.entity.Cafe;
 
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CafeMenu {
 
@@ -37,5 +36,14 @@ public class CafeMenu {
     private int price;
 
     private String imageUrl;
+
+    @Builder
+    public CafeMenu(Long id, Cafe cafe, String name, int price, String imageUrl) {
+        this.id = id;
+        this.cafe = cafe;
+        this.name = name;
+        this.price = price;
+        this.imageUrl = imageUrl;
+    }
 
 }

--- a/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
+++ b/src/main/java/shop/cazait/domain/cafemenu/entity/CafeMenu.java
@@ -37,8 +37,7 @@ public class CafeMenu {
     private String imageUrl;
 
     @Builder
-    public CafeMenu(Long id, Cafe cafe, String name, int price, String imageUrl) {
-        this.id = id;
+    public CafeMenu(Cafe cafe, String name, int price, String imageUrl) {
         this.cafe = cafe;
         this.name = name;
         this.price = price;

--- a/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
+++ b/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
@@ -9,7 +9,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
+++ b/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,9 +17,7 @@ import shop.cazait.domain.cafe.entity.Cafe;
 import shop.cazait.domain.user.entity.User;
 
 @Entity
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class CafeVisit {
 
@@ -36,4 +35,10 @@ public class CafeVisit {
     @Column(nullable = false)
     private Cafe cafe;
 
+    @Builder
+    public CafeVisit(Long id, User user, Cafe cafe) {
+        this.id = id;
+        this.user = user;
+        this.cafe = cafe;
+    }
 }

--- a/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
+++ b/src/main/java/shop/cazait/domain/cafevisit/entity/CafeVisit.java
@@ -35,8 +35,7 @@ public class CafeVisit {
     private Cafe cafe;
 
     @Builder
-    public CafeVisit(Long id, User user, Cafe cafe) {
-        this.id = id;
+    public CafeVisit(User user, Cafe cafe) {
         this.user = user;
         this.cafe = cafe;
     }


### PR DESCRIPTION
기존엔 클래스에 @Builder 어노테이션을 사용했지만 생성자 메소드를 생성하여 @Builder 어노테이션 설정 및 기본 생성자를 protected로 변환하여 객체의 일관성 유지